### PR TITLE
update example in readme adding the require of 'prisma-binding'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ type User {
 If you instantiate `Prisma` based on this service, you'll be able to send the following queries/mutations:
 
 ```js
+// Require Prisma class from prisma binding
+const { Prisma } = require('prisma-binding')
+
 // Instantiate `Prisma` based on concrete service
 const prisma = new Prisma({
   typeDefs: 'schemas/database.graphql',


### PR DESCRIPTION
I had a difficult time trying to understand how to use `prisma-binding` until I saw the source code and I inferred that I should require it like:

`const { Prisma } = require('prisma-binding')`

and I don't know if there is a section in the documentation that teach that.